### PR TITLE
Allow changes to use in `ilp_routing`

### DIFF
--- a/crates/interledger-ccp/src/packet.rs
+++ b/crates/interledger-ccp/src/packet.rs
@@ -188,7 +188,7 @@ impl RouteControlRequest {
         }
     }
 
-    fn try_from_data(mut data: &[u8]) -> Result<Self, CcpPacketError> {
+    pub fn try_from_data(mut data: &[u8]) -> Result<Self, CcpPacketError> {
         const MIN_LEN: usize = Mode::LEN
             + ROUTING_TABLE_ID_LEN
             // u32
@@ -470,7 +470,7 @@ impl RouteUpdateRequest {
         }
     }
 
-    fn try_from_data(mut data: &[u8]) -> Result<Self, CcpPacketError> {
+    pub fn try_from_data(mut data: &[u8]) -> Result<Self, CcpPacketError> {
         const HOLD_DOWN_TIME_LEN: usize = 4;
 
         const MIN_LEN: usize = ROUTING_TABLE_ID_LEN


### PR DESCRIPTION
To use certain methods in `ilp_routing` I have made the following changes.

- Make `try_from_data` public.
- Create a `to_data` to obtain the OER for just the `data` field instead of the whole Prepare packet, since that is the logic on the other `ilp_*` dependencies.